### PR TITLE
Return created item in all create responses

### DIFF
--- a/pfsenseapi/dhcp.go
+++ b/pfsenseapi/dhcp.go
@@ -120,17 +120,30 @@ func (s DHCPService) ListStaticMappings(ctx context.Context, netInterface string
 	return resp.Data, nil
 }
 
+type createStaticMappingResponse struct {
+	apiResponse
+	Data *DHCPStaticMapping `json:"data"`
+}
+
 // CreateStaticMapping creates a new DHCP static mapping.
-func (s DHCPService) CreateStaticMapping(ctx context.Context, newStaticMapping DHCPStaticMappingRequest) error {
+func (s DHCPService) CreateStaticMapping(
+	ctx context.Context,
+	newStaticMapping DHCPStaticMappingRequest,
+) (*DHCPStaticMapping, error) {
 	jsonData, err := json.Marshal(newStaticMapping)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.post(ctx, staticMappingEndpoint, nil, jsonData)
+	response, err := s.client.post(ctx, staticMappingEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createStaticMappingResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 type dhcpStaticMappingRequestUpdate struct {

--- a/pfsenseapi/firewall.go
+++ b/pfsenseapi/firewall.go
@@ -60,8 +60,17 @@ type firewallAliasRequestCreate struct {
 	Apply bool `json:"apply"`
 }
 
-// CreateAlias creates a new Alias
-func (s FirewallService) CreateAlias(ctx context.Context, newAlias FirewallAliasRequest, apply bool) error {
+type createAliasResponse struct {
+	apiResponse
+	Data *FirewallAlias `json:"data"`
+}
+
+// CreateAlias creates a new Alias.
+func (s FirewallService) CreateAlias(
+	ctx context.Context,
+	newAlias FirewallAliasRequest,
+	apply bool,
+) (*FirewallAlias, error) {
 	requestData := firewallAliasRequestCreate{
 		FirewallAliasRequest: newAlias,
 		Apply:                apply,
@@ -69,13 +78,18 @@ func (s FirewallService) CreateAlias(ctx context.Context, newAlias FirewallAlias
 
 	jsonData, err := json.Marshal(requestData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.post(ctx, aliasEndpoint, nil, jsonData)
+	response, err := s.client.post(ctx, aliasEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createAliasResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 // DeleteAlias deletes a firewall Alias
@@ -271,21 +285,35 @@ type firewallRuleCreateRequest struct {
 	Apply bool `json:"apply"`
 }
 
+type createRuleResponse struct {
+	apiResponse
+	Data *FirewallRule `json:"data"`
+}
+
 // CreateRule creates a new Rule
-func (s FirewallService) CreateRule(ctx context.Context, newRule FirewallRuleRequest, apply bool) error {
+func (s FirewallService) CreateRule(
+	ctx context.Context,
+	newRule FirewallRuleRequest,
+	apply bool,
+) (*FirewallRule, error) {
 	requestData := firewallRuleCreateRequest{
 		FirewallRuleRequest: newRule,
 		Apply:               apply,
 	}
 	jsonData, err := json.Marshal(requestData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.post(ctx, ruleEndpoint, nil, jsonData)
+	response, err := s.client.post(ctx, ruleEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createRuleResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 type firewallRuleUpdateRequest struct {

--- a/pfsenseapi/interface.go
+++ b/pfsenseapi/interface.go
@@ -138,17 +138,31 @@ type InterfaceRequest struct {
 	Type6                         string   `json:"type6"`
 }
 
+type createInterfaceResponse struct {
+	apiResponse
+	Data *Interface `json:"data"`
+}
+
 // CreateInterface creates a new interface.
-func (s InterfaceService) CreateInterface(ctx context.Context, newInterface InterfaceRequest) error {
+func (s InterfaceService) CreateInterface(
+	ctx context.Context,
+	newInterface InterfaceRequest,
+) (*Interface, error) {
 	jsonData, err := json.Marshal(newInterface)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.post(ctx, interfaceEndpoint, nil, jsonData)
+
+	response, err := s.client.post(ctx, interfaceEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createInterfaceResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 type interfaceRequestUpdate struct {
@@ -226,17 +240,31 @@ type VLANRequest struct {
 	Tag   int    `json:"tag"`
 }
 
+type createVLANResponse struct {
+	apiResponse
+	Data *VLAN `json:"data"`
+}
+
 // CreateVLAN creates a new VLAN.
-func (s InterfaceService) CreateVLAN(ctx context.Context, newVLAN VLANRequest) error {
+func (s InterfaceService) CreateVLAN(
+	ctx context.Context,
+	newVLAN VLANRequest,
+) (*VLAN, error) {
 	jsonData, err := json.Marshal(newVLAN)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.post(ctx, interfaceVLANEndpoint, nil, jsonData)
+
+	response, err := s.client.post(ctx, interfaceVLANEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createVLANResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 type vlanRequestUpdate struct {
@@ -310,17 +338,30 @@ type InterfaceGroupRequestCreate struct {
 	Ifname  string   `json:"ifname"`
 }
 
+type createInterfaceGroupResponse struct {
+	apiResponse
+	Data *InterfaceGroup `json:"data"`
+}
+
 // CreateInterfaceGroup creates a new interface group.
-func (s InterfaceService) CreateInterfaceGroup(ctx context.Context, newGroup InterfaceGroupRequestCreate) error {
+func (s InterfaceService) CreateInterfaceGroup(
+	ctx context.Context,
+	newGroup InterfaceGroupRequestCreate,
+) (*InterfaceGroup, error) {
 	jsonData, err := json.Marshal(newGroup)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.post(ctx, interfaceGroupEndpoint, nil, jsonData)
+	response, err := s.client.post(ctx, interfaceGroupEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createInterfaceGroupResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 type InterfaceGroupRequestUpdate struct {

--- a/pfsenseapi/routing.go
+++ b/pfsenseapi/routing.go
@@ -79,17 +79,31 @@ type GatewayRequest struct {
 	Weight         int    `json:"weight"`
 }
 
+type createGatewayResponse struct {
+	apiResponse
+	Data *Gateway `json:"data"`
+}
+
 // CreateGateway creates a new Gateway
-func (s RoutingService) CreateGateway(ctx context.Context, newGateway GatewayRequest) error {
+func (s RoutingService) CreateGateway(
+	ctx context.Context,
+	newGateway GatewayRequest,
+) (*Gateway, error) {
 	jsonData, err := json.Marshal(newGateway)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.post(ctx, gatewayEndpoint, nil, jsonData)
+
+	response, err := s.client.post(ctx, gatewayEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createGatewayResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 // DeleteGateway deletes a Gateway

--- a/pfsenseapi/system.go
+++ b/pfsenseapi/system.go
@@ -264,17 +264,30 @@ type CACertificateRequest struct {
 	Trust                bool   `json:"trust"`
 }
 
+type createCACertificateResponse struct {
+	apiResponse
+	Data *CACertificate `json:"data"`
+}
+
 // CreateCACertificate generate or import new CA certificate.
-func (s SystemService) CreateCACertificate(ctx context.Context, newCACertificate CACertificateRequest) error {
+func (s SystemService) CreateCACertificate(
+	ctx context.Context,
+	newCACertificate CACertificateRequest,
+) (*CACertificate, error) {
 	jsonData, err := json.Marshal(newCACertificate)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.post(ctx, caCertificatesEndpoint, nil, jsonData)
+	response, err := s.client.post(ctx, caCertificatesEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createCACertificateResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 // Certificate represents a single installed SSL/TLS certificate.
@@ -352,17 +365,30 @@ type CertificateCreateRequest struct {
 	Type                 string `json:"type"`
 }
 
+type createCertificateResponse struct {
+	apiResponse
+	Data *Certificate `json:"data"`
+}
+
 // CreateCertificate generate or import new certificate.
-func (s SystemService) CreateCertificate(ctx context.Context, newCertificate CertificateCreateRequest) error {
+func (s SystemService) CreateCertificate(
+	ctx context.Context,
+	newCertificate CertificateCreateRequest,
+) (*Certificate, error) {
 	jsonData, err := json.Marshal(newCertificate)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.post(ctx, certificateEndpoint, nil, jsonData)
+	response, err := s.client.post(ctx, certificateEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createCertificateResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 // CertificateUpdateRequest is used to update a certificate.
@@ -704,17 +730,30 @@ type TunableRequest struct {
 	Value   string `json:"value"`
 }
 
+type createTunableResponse struct {
+	apiResponse
+	Data *Tunable `json:"data"`
+}
+
 // CreateTunable creates a new system tunable.
-func (s SystemService) CreateTunable(ctx context.Context, newTunable TunableRequest) error {
+func (s SystemService) CreateTunable(
+	ctx context.Context,
+	newTunable TunableRequest,
+) (*Tunable, error) {
 	jsonData, err := json.Marshal(newTunable)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.post(ctx, tunableEndpoint, nil, jsonData)
+	response, err := s.client.post(ctx, tunableEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createTunableResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 type tunableRequestUpdate struct {

--- a/pfsenseapi/user.go
+++ b/pfsenseapi/user.go
@@ -78,17 +78,31 @@ type UserRequest struct {
 	Username       string   `json:"username"`
 }
 
+type createUserResponse struct {
+	apiResponse
+	Data *User `json:"data"`
+}
+
 // CreateUser creates a new User.
-func (s UserService) CreateUser(ctx context.Context, newUser UserRequest) error {
+func (s UserService) CreateUser(
+	ctx context.Context,
+	newUser UserRequest,
+) (*User, error) {
 	jsonData, err := json.Marshal(newUser)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	if _, err = s.client.post(ctx, userEndpoint, nil, jsonData); err != nil {
-		return err
+	response, err := s.client.post(ctx, userEndpoint, nil, jsonData)
+	if err != nil {
+		return nil, err
 	}
-	return nil
+
+	resp := new(createUserResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 // UpdateUser updates a user.
@@ -156,17 +170,31 @@ type GroupRequest struct {
 	Priv        []string `json:"priv"`
 }
 
+type createGroupResponse struct {
+	apiResponse
+	Data *Group `json:"data"`
+}
+
 // CreateGroup creates a new Group.
-func (s UserService) CreateGroup(ctx context.Context, newGroup GroupRequest) error {
+func (s UserService) CreateGroup(
+	ctx context.Context,
+	newGroup GroupRequest,
+) (*Group, error) {
 	jsonData, err := json.Marshal(newGroup)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	if _, err = s.client.post(ctx, groupEndpoint, nil, jsonData); err != nil {
-		return err
+	response, err := s.client.post(ctx, groupEndpoint, nil, jsonData)
+	if err != nil {
+		return nil, err
 	}
-	return nil
+
+	resp := new(createGroupResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 type groupRequestUpdate struct {


### PR DESCRIPTION
Proposal for change in https://github.com/sjafferali/pfsense-api-goclient/pull/41 . 

This change is a breaking change that changes the response of all Create methods to return the newly created item. 