### PR TITLE
Return updated entry in Update responses

### DIFF
--- a/pfsenseapi/dhcp.go
+++ b/pfsenseapi/dhcp.go
@@ -152,7 +152,11 @@ type dhcpStaticMappingRequestUpdate struct {
 }
 
 // UpdateStaticMapping modifies a DHCP static mapping.
-func (s DHCPService) UpdateStaticMapping(ctx context.Context, idToUpdate int, mappingData DHCPStaticMappingRequest) error {
+func (s DHCPService) UpdateStaticMapping(
+	ctx context.Context,
+	idToUpdate int,
+	mappingData DHCPStaticMappingRequest,
+) (*DHCPStaticMapping, error) {
 	requestData := dhcpStaticMappingRequestUpdate{
 		DHCPStaticMappingRequest: mappingData,
 		Id:                       idToUpdate,
@@ -160,13 +164,18 @@ func (s DHCPService) UpdateStaticMapping(ctx context.Context, idToUpdate int, ma
 
 	jsonData, err := json.Marshal(requestData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.put(ctx, staticMappingEndpoint, nil, jsonData)
+	response, err := s.client.put(ctx, staticMappingEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createStaticMappingResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 // DeleteStaticMapping deletes a DHCP static mapping.

--- a/pfsenseapi/firewall.go
+++ b/pfsenseapi/firewall.go
@@ -115,7 +115,12 @@ type firewallAliasRequestUpdate struct {
 }
 
 // UpdateAlias modifies an existing alias
-func (s FirewallService) UpdateAlias(ctx context.Context, aliasToUpdate string, newAliasData FirewallAliasRequest, apply bool) error {
+func (s FirewallService) UpdateAlias(
+	ctx context.Context,
+	aliasToUpdate string,
+	newAliasData FirewallAliasRequest,
+	apply bool,
+) (*FirewallAlias, error) {
 	requestData := firewallAliasRequestUpdate{
 		FirewallAliasRequest: newAliasData,
 		Apply:                apply,
@@ -124,13 +129,19 @@ func (s FirewallService) UpdateAlias(ctx context.Context, aliasToUpdate string, 
 
 	jsonData, err := json.Marshal(requestData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.put(ctx, aliasEndpoint, nil, jsonData)
+
+	response, err := s.client.put(ctx, aliasEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createAliasResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 // DeleteAliasEntry deletes a address from a firewall alias
@@ -323,7 +334,12 @@ type firewallRuleUpdateRequest struct {
 }
 
 // UpdateRule modifies an existing rule
-func (s FirewallService) UpdateRule(ctx context.Context, ruleToUpdate int, newRuleData FirewallRuleRequest, apply bool) error {
+func (s FirewallService) UpdateRule(
+	ctx context.Context,
+	ruleToUpdate int,
+	newRuleData FirewallRuleRequest,
+	apply bool,
+) (*FirewallRule, error) {
 	requestData := firewallRuleUpdateRequest{
 		FirewallRuleRequest: newRuleData,
 		Apply:               apply,
@@ -332,11 +348,17 @@ func (s FirewallService) UpdateRule(ctx context.Context, ruleToUpdate int, newRu
 
 	jsonData, err := json.Marshal(requestData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.put(ctx, ruleEndpoint, nil, jsonData)
+
+	response, err := s.client.put(ctx, ruleEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createRuleResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }

--- a/pfsenseapi/interface.go
+++ b/pfsenseapi/interface.go
@@ -171,7 +171,11 @@ type interfaceRequestUpdate struct {
 }
 
 // UpdateInterface modifies an existing interface.
-func (s InterfaceService) UpdateInterface(ctx context.Context, idToUpdate int, interfaceData InterfaceRequest) error {
+func (s InterfaceService) UpdateInterface(
+	ctx context.Context,
+	idToUpdate int,
+	interfaceData InterfaceRequest,
+) (*Interface, error) {
 	requestData := interfaceRequestUpdate{
 		InterfaceRequest: interfaceData,
 		Id:               strconv.Itoa(idToUpdate),
@@ -179,14 +183,19 @@ func (s InterfaceService) UpdateInterface(ctx context.Context, idToUpdate int, i
 
 	jsonData, err := json.Marshal(requestData)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = s.client.put(ctx, interfaceEndpoint, nil, jsonData)
+	response, err := s.client.put(ctx, interfaceEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createInterfaceResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 // VLAN represents a single VLAN.
@@ -273,7 +282,11 @@ type vlanRequestUpdate struct {
 }
 
 // UpdateVLAN modifies an existing VLAN.
-func (s InterfaceService) UpdateVLAN(ctx context.Context, idToUpdate int, vlanData VLANRequest) error {
+func (s InterfaceService) UpdateVLAN(
+	ctx context.Context,
+	idToUpdate int,
+	vlanData VLANRequest,
+) (*VLAN, error) {
 	requestData := vlanRequestUpdate{
 		VLANRequest: vlanData,
 		Id:          idToUpdate,
@@ -281,14 +294,19 @@ func (s InterfaceService) UpdateVLAN(ctx context.Context, idToUpdate int, vlanDa
 
 	jsonData, err := json.Marshal(requestData)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = s.client.put(ctx, interfaceEndpoint, nil, jsonData)
+	response, err := s.client.put(ctx, interfaceEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createVLANResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 type InterfaceGroup struct {
@@ -371,16 +389,25 @@ type InterfaceGroupRequestUpdate struct {
 }
 
 // UpdateInterfaceGroup updates an existing interface group.
-func (s InterfaceService) UpdateInterfaceGroup(ctx context.Context, groupData InterfaceGroupRequestUpdate) error {
+func (s InterfaceService) UpdateInterfaceGroup(
+	ctx context.Context,
+	groupData InterfaceGroupRequestUpdate,
+) (*InterfaceGroup, error) {
 	jsonData, err := json.Marshal(groupData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.put(ctx, interfaceGroupEndpoint, nil, jsonData)
+
+	response, err := s.client.put(ctx, interfaceGroupEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createInterfaceGroupResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 type applyInterfaceRequest struct {

--- a/pfsenseapi/routing.go
+++ b/pfsenseapi/routing.go
@@ -116,16 +116,25 @@ func (s RoutingService) DeleteGateway(ctx context.Context, gatewayID int) error 
 }
 
 // UpdateGateway modifies a existing gateway
-func (s RoutingService) UpdateGateway(ctx context.Context, gatewayToUpdate GatewayRequest) error {
+func (s RoutingService) UpdateGateway(
+	ctx context.Context,
+	gatewayToUpdate GatewayRequest,
+) (*Gateway, error) {
 	jsonData, err := json.Marshal(gatewayToUpdate)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.put(ctx, gatewayEndpoint, nil, jsonData)
+
+	response, err := s.client.put(ctx, gatewayEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createGatewayResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 type DefaultGatewayRequest struct {

--- a/pfsenseapi/system.go
+++ b/pfsenseapi/system.go
@@ -409,7 +409,7 @@ func (s SystemService) UpdateCertificate(
 	ctx context.Context,
 	refIDToUpdate string,
 	newCertificateData CertificateUpdateRequest,
-) error {
+) (*Certificate, error) {
 	requestData := certificateUpdateRequest{
 		CertificateUpdateRequest: newCertificateData,
 		Refid:                    refIDToUpdate,
@@ -417,13 +417,18 @@ func (s SystemService) UpdateCertificate(
 
 	jsonData, err := json.Marshal(requestData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.put(ctx, certificateEndpoint, nil, jsonData)
+	response, err := s.client.put(ctx, certificateEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createCertificateResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 // DNSConfiguration represents the system DNS configuration.
@@ -762,7 +767,11 @@ type tunableRequestUpdate struct {
 }
 
 // UpdateTunable modifies an existing tunable.
-func (s SystemService) UpdateTunable(ctx context.Context, tunableToUpdate string, newTunable TunableRequest) error {
+func (s SystemService) UpdateTunable(
+	ctx context.Context,
+	tunableToUpdate string,
+	newTunable TunableRequest,
+) (*Tunable, error) {
 	requestData := tunableRequestUpdate{
 		TunableRequest: newTunable,
 		Id:             tunableToUpdate,
@@ -770,13 +779,19 @@ func (s SystemService) UpdateTunable(ctx context.Context, tunableToUpdate string
 
 	jsonData, err := json.Marshal(requestData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.put(ctx, tunableEndpoint, nil, jsonData)
+
+	response, err := s.client.put(ctx, tunableEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createTunableResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 // Version represents the system version.

--- a/pfsenseapi/user.go
+++ b/pfsenseapi/user.go
@@ -106,16 +106,25 @@ func (s UserService) CreateUser(
 }
 
 // UpdateUser updates a user.
-func (s UserService) UpdateUser(ctx context.Context, userData UserRequest) error {
+func (s UserService) UpdateUser(
+	ctx context.Context,
+	userData UserRequest,
+) (*User, error) {
 	jsonData, err := json.Marshal(userData)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	if _, err = s.client.put(ctx, userEndpoint, nil, jsonData); err != nil {
-		return err
+	response, err := s.client.put(ctx, userEndpoint, nil, jsonData)
+	if err != nil {
+		return nil, err
 	}
-	return nil
+
+	resp := new(createUserResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 // Group represents a single user group.
@@ -203,7 +212,11 @@ type groupRequestUpdate struct {
 }
 
 // UpdateGroup modifies an existing group.
-func (s UserService) UpdateGroup(ctx context.Context, groupToUpdate string, newGroupData GroupRequest) error {
+func (s UserService) UpdateGroup(
+	ctx context.Context,
+	groupToUpdate string,
+	newGroupData GroupRequest,
+) (*Group, error) {
 	requestData := groupRequestUpdate{
 		GroupRequest: newGroupData,
 		Id:           groupToUpdate,
@@ -211,13 +224,18 @@ func (s UserService) UpdateGroup(ctx context.Context, groupToUpdate string, newG
 
 	jsonData, err := json.Marshal(requestData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = s.client.put(ctx, groupEndpoint, nil, jsonData)
+	response, err := s.client.put(ctx, groupEndpoint, nil, jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	resp := new(createGroupResponse)
+	if err = json.Unmarshal(response, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 type userGroupsRequest struct {

--- a/pfsenseapi/user_test.go
+++ b/pfsenseapi/user_test.go
@@ -73,6 +73,7 @@ func TestUserService_UpdateGroup(t *testing.T) {
 	defer server.Close()
 
 	newClient := NewClientWithNoAuth(server.URL)
-	err := newClient.User.UpdateGroup(context.Background(), "admin", GroupRequest{})
+	response, err := newClient.User.UpdateGroup(context.Background(), "admin", GroupRequest{})
+	require.NotNil(t, response)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
This change is a breaking change that changes the response of all Updated methods to return the newly updated item.

Related to https://github.com/sjafferali/pfsense-api-goclient/pull/43